### PR TITLE
Fix pipeline behavior overload selection

### DIFF
--- a/src/Medino.Tests/PipelineBehaviors/ContextPipelineBehaviorTests.cs
+++ b/src/Medino.Tests/PipelineBehaviors/ContextPipelineBehaviorTests.cs
@@ -262,6 +262,30 @@ public class ContextPipelineBehaviorTests : IDisposable
         // Assert
         Assert.IsAssignableFrom<IReadOnlyDictionary<string, object>>(metadata);
     }
+
+    [Fact]
+    public async Task ContextPipelineBehavior_WithMultipleClosedHandleAsyncOverloads_ShouldInvokeMatchingOverload()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton<OverloadedContextPipelineBehavior>();
+        services.AddSingleton<IContextPipelineBehavior<OverloadedFirstContextRequest, string>>(sp => sp.GetRequiredService<OverloadedContextPipelineBehavior>());
+        services.AddSingleton<IContextPipelineBehavior<OverloadedSecondContextRequest, string>>(sp => sp.GetRequiredService<OverloadedContextPipelineBehavior>());
+        services.AddMedino(typeof(ContextPipelineBehaviorTests).Assembly);
+        var serviceProvider = services.BuildServiceProvider();
+        var mediator = serviceProvider.GetRequiredService<IMediator>();
+        var behavior = serviceProvider.GetRequiredService<OverloadedContextPipelineBehavior>();
+
+        // Act
+        var response = await mediator.SendAsync(new OverloadedSecondContextRequest("second"));
+
+        // Assert
+        Assert.Equal("Handled second", response);
+        Assert.Equal("second", behavior.InvokedOverload);
+
+        // Cleanup
+        (serviceProvider as IDisposable)?.Dispose();
+    }
 }
 
 // Test request and handlers for tenant enrichment
@@ -409,6 +433,45 @@ public class ObservingBehavior : IPipelineBehavior<object, string>
         {
             ObservedValue = combined.Value;
         }
+        return await next();
+    }
+}
+
+public record OverloadedFirstContextRequest(string Value) : IRequest<string>;
+
+public record OverloadedSecondContextRequest(string Value) : IRequest<string>;
+
+public class OverloadedFirstContextRequestHandler : IRequestHandler<OverloadedFirstContextRequest, string>
+{
+    public Task<string> HandleAsync(OverloadedFirstContextRequest request, CancellationToken cancellationToken)
+    {
+        return Task.FromResult($"Handled {request.Value}");
+    }
+}
+
+public class OverloadedSecondContextRequestHandler : IRequestHandler<OverloadedSecondContextRequest, string>
+{
+    public Task<string> HandleAsync(OverloadedSecondContextRequest request, CancellationToken cancellationToken)
+    {
+        return Task.FromResult($"Handled {request.Value}");
+    }
+}
+
+public class OverloadedContextPipelineBehavior :
+    IContextPipelineBehavior<OverloadedFirstContextRequest, string>,
+    IContextPipelineBehavior<OverloadedSecondContextRequest, string>
+{
+    public string? InvokedOverload { get; private set; }
+
+    public async Task<string> HandleAsync(PipelineContext<OverloadedFirstContextRequest> context, RequestHandlerDelegate<string> next, CancellationToken cancellationToken)
+    {
+        InvokedOverload = "first";
+        return await next();
+    }
+
+    public async Task<string> HandleAsync(PipelineContext<OverloadedSecondContextRequest> context, RequestHandlerDelegate<string> next, CancellationToken cancellationToken)
+    {
+        InvokedOverload = "second";
         return await next();
     }
 }

--- a/src/Medino.Tests/PipelineBehaviors/ContextPipelineBehaviorTests.cs
+++ b/src/Medino.Tests/PipelineBehaviors/ContextPipelineBehaviorTests.cs
@@ -263,10 +263,18 @@ public class ContextPipelineBehaviorTests : IDisposable
         Assert.IsAssignableFrom<IReadOnlyDictionary<string, object>>(metadata);
     }
 
+    // Regression test for AmbiguousMatchException on context behaviors - the same defect as the
+    // regular-pipeline test, on the IContextPipelineBehavior<,> invocation path.
+    //
+    // When one class implements multiple closed IContextPipelineBehavior<,> interfaces it declares
+    // multiple HandleAsync overloads. Resolving HandleAsync by name on the concrete type matches more
+    // than one and throws AmbiguousMatchException. The fix resolves the method on the closed interface
+    // the behavior was registered as, which exposes exactly one HandleAsync, selecting the right overload.
     [Fact]
     public async Task ContextPipelineBehavior_WithMultipleClosedHandleAsyncOverloads_ShouldInvokeMatchingOverload()
     {
-        // Arrange
+        // Arrange - register one shared instance behind both closed IContextPipelineBehavior<,>
+        // interfaces so a single InvokedOverload field can record which overload actually ran.
         var services = new ServiceCollection();
         services.AddSingleton<OverloadedContextPipelineBehavior>();
         services.AddSingleton<IContextPipelineBehavior<OverloadedFirstContextRequest, string>>(sp => sp.GetRequiredService<OverloadedContextPipelineBehavior>());
@@ -276,7 +284,8 @@ public class ContextPipelineBehaviorTests : IDisposable
         var mediator = serviceProvider.GetRequiredService<IMediator>();
         var behavior = serviceProvider.GetRequiredService<OverloadedContextPipelineBehavior>();
 
-        // Act & Assert - each request type must resolve to its own HandleAsync overload
+        // Act & Assert - send each request type and confirm its matching HandleAsync overload ran.
+        // Both directions are exercised so a fix that hard-coded a single overload would still fail.
         var secondResponse = await mediator.SendAsync(new OverloadedSecondContextRequest("second"));
         Assert.Equal("Handled second", secondResponse);
         Assert.Equal("second", behavior.InvokedOverload);
@@ -459,10 +468,14 @@ public class OverloadedSecondContextRequestHandler : IRequestHandler<OverloadedS
     }
 }
 
+// Implements two closed IContextPipelineBehavior<,> interfaces, so the concrete type declares two
+// HandleAsync overloads - the shape that triggered AmbiguousMatchException when the mediator resolved
+// HandleAsync by name on the concrete type.
 public class OverloadedContextPipelineBehavior :
     IContextPipelineBehavior<OverloadedFirstContextRequest, string>,
     IContextPipelineBehavior<OverloadedSecondContextRequest, string>
 {
+    // Records which overload the mediator actually invoked, so the test can assert correct dispatch.
     public string? InvokedOverload { get; private set; }
 
     public async Task<string> HandleAsync(PipelineContext<OverloadedFirstContextRequest> context, RequestHandlerDelegate<string> next, CancellationToken cancellationToken)

--- a/src/Medino.Tests/PipelineBehaviors/ContextPipelineBehaviorTests.cs
+++ b/src/Medino.Tests/PipelineBehaviors/ContextPipelineBehaviorTests.cs
@@ -276,12 +276,14 @@ public class ContextPipelineBehaviorTests : IDisposable
         var mediator = serviceProvider.GetRequiredService<IMediator>();
         var behavior = serviceProvider.GetRequiredService<OverloadedContextPipelineBehavior>();
 
-        // Act
-        var response = await mediator.SendAsync(new OverloadedSecondContextRequest("second"));
-
-        // Assert
-        Assert.Equal("Handled second", response);
+        // Act & Assert - each request type must resolve to its own HandleAsync overload
+        var secondResponse = await mediator.SendAsync(new OverloadedSecondContextRequest("second"));
+        Assert.Equal("Handled second", secondResponse);
         Assert.Equal("second", behavior.InvokedOverload);
+
+        var firstResponse = await mediator.SendAsync(new OverloadedFirstContextRequest("first"));
+        Assert.Equal("Handled first", firstResponse);
+        Assert.Equal("first", behavior.InvokedOverload);
 
         // Cleanup
         (serviceProvider as IDisposable)?.Dispose();

--- a/src/Medino.Tests/PipelineBehaviors/PipelineBehaviorTests.cs
+++ b/src/Medino.Tests/PipelineBehaviors/PipelineBehaviorTests.cs
@@ -109,4 +109,67 @@ public class PipelineBehaviorTests : IDisposable
         // Cleanup
         (serviceProvider as IDisposable)?.Dispose();
     }
+
+    [Fact]
+    public async Task PipelineBehavior_WithMultipleClosedHandleAsyncOverloads_ShouldInvokeMatchingOverload()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton<OverloadedPipelineBehavior>();
+        services.AddSingleton<IPipelineBehavior<OverloadedFirstRequest, string>>(sp => sp.GetRequiredService<OverloadedPipelineBehavior>());
+        services.AddSingleton<IPipelineBehavior<OverloadedSecondRequest, string>>(sp => sp.GetRequiredService<OverloadedPipelineBehavior>());
+        services.AddMedino(typeof(PipelineBehaviorTests).Assembly);
+        var serviceProvider = services.BuildServiceProvider();
+        var mediator = serviceProvider.GetRequiredService<IMediator>();
+        var behavior = serviceProvider.GetRequiredService<OverloadedPipelineBehavior>();
+
+        // Act
+        var response = await mediator.SendAsync(new OverloadedSecondRequest("second"));
+
+        // Assert
+        Assert.Equal("Handled second", response);
+        Assert.Equal("second", behavior.InvokedOverload);
+
+        // Cleanup
+        (serviceProvider as IDisposable)?.Dispose();
+    }
+}
+
+public record OverloadedFirstRequest(string Value) : IRequest<string>;
+
+public record OverloadedSecondRequest(string Value) : IRequest<string>;
+
+public class OverloadedFirstRequestHandler : IRequestHandler<OverloadedFirstRequest, string>
+{
+    public Task<string> HandleAsync(OverloadedFirstRequest request, CancellationToken cancellationToken)
+    {
+        return Task.FromResult($"Handled {request.Value}");
+    }
+}
+
+public class OverloadedSecondRequestHandler : IRequestHandler<OverloadedSecondRequest, string>
+{
+    public Task<string> HandleAsync(OverloadedSecondRequest request, CancellationToken cancellationToken)
+    {
+        return Task.FromResult($"Handled {request.Value}");
+    }
+}
+
+public class OverloadedPipelineBehavior :
+    IPipelineBehavior<OverloadedFirstRequest, string>,
+    IPipelineBehavior<OverloadedSecondRequest, string>
+{
+    public string? InvokedOverload { get; private set; }
+
+    public async Task<string> HandleAsync(OverloadedFirstRequest request, RequestHandlerDelegate<string> next, CancellationToken cancellationToken)
+    {
+        InvokedOverload = "first";
+        return await next();
+    }
+
+    public async Task<string> HandleAsync(OverloadedSecondRequest request, RequestHandlerDelegate<string> next, CancellationToken cancellationToken)
+    {
+        InvokedOverload = "second";
+        return await next();
+    }
 }

--- a/src/Medino.Tests/PipelineBehaviors/PipelineBehaviorTests.cs
+++ b/src/Medino.Tests/PipelineBehaviors/PipelineBehaviorTests.cs
@@ -110,10 +110,25 @@ public class PipelineBehaviorTests : IDisposable
         (serviceProvider as IDisposable)?.Dispose();
     }
 
+    // Regression test for AmbiguousMatchException when a single class implements more than one
+    // closed IPipelineBehavior<,> interface.
+    //
+    // The mediator invokes a behavior's HandleAsync via reflection. It previously resolved the method
+    // with concreteType.GetMethod("HandleAsync"), which inspects the implementation type. When that
+    // type declares two HandleAsync overloads (one per closed interface it implements), GetMethod finds
+    // more than one match and throws AmbiguousMatchException before the handler ever runs.
+    //
+    // The fix resolves HandleAsync on the *closed interface* the behavior was registered as
+    // (IPipelineBehavior<OverloadedSecondRequest, string>), which exposes exactly one HandleAsync,
+    // so the correct overload is selected for each request type.
+    //
+    // The OverloadedPipelineBehavior below reproduces the failing shape (one class, two closed
+    // interfaces, two overloads), registered as a shared singleton behind both interfaces.
     [Fact]
     public async Task PipelineBehavior_WithMultipleClosedHandleAsyncOverloads_ShouldInvokeMatchingOverload()
     {
-        // Arrange
+        // Arrange - register one shared instance behind both closed IPipelineBehavior<,> interfaces.
+        // The shared instance lets a single InvokedOverload field record which overload actually ran.
         var services = new ServiceCollection();
         services.AddSingleton<OverloadedPipelineBehavior>();
         services.AddSingleton<IPipelineBehavior<OverloadedFirstRequest, string>>(sp => sp.GetRequiredService<OverloadedPipelineBehavior>());
@@ -123,7 +138,8 @@ public class PipelineBehaviorTests : IDisposable
         var mediator = serviceProvider.GetRequiredService<IMediator>();
         var behavior = serviceProvider.GetRequiredService<OverloadedPipelineBehavior>();
 
-        // Act & Assert - each request type must resolve to its own HandleAsync overload
+        // Act & Assert - send each request type and confirm its matching HandleAsync overload ran.
+        // Both directions are exercised so a fix that hard-coded a single overload would still fail.
         var secondResponse = await mediator.SendAsync(new OverloadedSecondRequest("second"));
         Assert.Equal("Handled second", secondResponse);
         Assert.Equal("second", behavior.InvokedOverload);
@@ -157,10 +173,14 @@ public class OverloadedSecondRequestHandler : IRequestHandler<OverloadedSecondRe
     }
 }
 
+// Implements two closed IPipelineBehavior<,> interfaces, so the concrete type declares two
+// HandleAsync overloads. This is the exact shape that triggered AmbiguousMatchException when the
+// mediator resolved HandleAsync by name on the concrete type.
 public class OverloadedPipelineBehavior :
     IPipelineBehavior<OverloadedFirstRequest, string>,
     IPipelineBehavior<OverloadedSecondRequest, string>
 {
+    // Records which overload the mediator actually invoked, so the test can assert correct dispatch.
     public string? InvokedOverload { get; private set; }
 
     public async Task<string> HandleAsync(OverloadedFirstRequest request, RequestHandlerDelegate<string> next, CancellationToken cancellationToken)

--- a/src/Medino.Tests/PipelineBehaviors/PipelineBehaviorTests.cs
+++ b/src/Medino.Tests/PipelineBehaviors/PipelineBehaviorTests.cs
@@ -123,12 +123,14 @@ public class PipelineBehaviorTests : IDisposable
         var mediator = serviceProvider.GetRequiredService<IMediator>();
         var behavior = serviceProvider.GetRequiredService<OverloadedPipelineBehavior>();
 
-        // Act
-        var response = await mediator.SendAsync(new OverloadedSecondRequest("second"));
-
-        // Assert
-        Assert.Equal("Handled second", response);
+        // Act & Assert - each request type must resolve to its own HandleAsync overload
+        var secondResponse = await mediator.SendAsync(new OverloadedSecondRequest("second"));
+        Assert.Equal("Handled second", secondResponse);
         Assert.Equal("second", behavior.InvokedOverload);
+
+        var firstResponse = await mediator.SendAsync(new OverloadedFirstRequest("first"));
+        Assert.Equal("Handled first", firstResponse);
+        Assert.Equal("first", behavior.InvokedOverload);
 
         // Cleanup
         (serviceProvider as IDisposable)?.Dispose();

--- a/src/Medino/Mediator.cs
+++ b/src/Medino/Mediator.cs
@@ -59,19 +59,27 @@ public class Mediator : IMediator
         // Get context behaviors (for request transformation)
         // Look for both concrete type and object-based behaviors
         var contextBehaviorType = typeof(IContextPipelineBehavior<,>).MakeGenericType(requestType, typeof(TResponse));
-        var contextBehaviors = GetServices(contextBehaviorType).ToList();
+        var contextBehaviors = GetServices(contextBehaviorType)
+            .Select(behavior => (Behavior: behavior, ServiceType: contextBehaviorType))
+            .ToList();
 
         var objectContextBehaviorType = typeof(IContextPipelineBehavior<,>).MakeGenericType(typeof(object), typeof(TResponse));
-        var objectContextBehaviors = GetServices(objectContextBehaviorType).ToList();
+        var objectContextBehaviors = GetServices(objectContextBehaviorType)
+            .Select(behavior => (Behavior: behavior, ServiceType: objectContextBehaviorType))
+            .ToList();
         contextBehaviors.AddRange(objectContextBehaviors);
 
         // Get regular pipeline behaviors
         // Look for both concrete type and object-based behaviors
         var normalBehaviorType = typeof(IPipelineBehavior<,>).MakeGenericType(requestType, typeof(TResponse));
-        var behaviors = GetServices(normalBehaviorType).ToList();
+        var behaviors = GetServices(normalBehaviorType)
+            .Select(behavior => (Behavior: behavior, ServiceType: normalBehaviorType))
+            .ToList();
 
         var objectBehaviorType = typeof(IPipelineBehavior<,>).MakeGenericType(typeof(object), typeof(TResponse));
-        var objectBehaviors = GetServices(objectBehaviorType).ToList();
+        var objectBehaviors = GetServices(objectBehaviorType)
+            .Select(behavior => (Behavior: behavior, ServiceType: objectBehaviorType))
+            .ToList();
         behaviors.AddRange(objectBehaviors);
 
         if (contextBehaviors.Count > 0 || behaviors.Count > 0)
@@ -118,15 +126,14 @@ public class Mediator : IMediator
             // Add regular pipeline behaviors (execute after context behaviors)
             for (var i = behaviors.Count - 1; i >= 0; i--)
             {
-                var behavior = behaviors[i];
+                var (behavior, behaviorServiceType) = behaviors[i];
                 var next = pipeline;
 
-                var behaviorType = behavior.GetType();
-                var handleAsyncMethod = behaviorType.GetMethod(nameof(IPipelineBehavior<object, TResponse>.HandleAsync));
+                var handleAsyncMethod = behaviorServiceType.GetMethod(nameof(IPipelineBehavior<object, TResponse>.HandleAsync));
 
                 if (handleAsyncMethod == null)
                 {
-                    throw new InvalidOperationException($"HandleAsync method not found on pipeline behavior {behaviorType.Name}");
+                    throw new InvalidOperationException($"HandleAsync method not found on pipeline behavior {behaviorServiceType.Name}");
                 }
 
                 pipeline = () =>
@@ -154,16 +161,15 @@ public class Mediator : IMediator
             // Add context behaviors (execute first, can transform request)
             for (var i = contextBehaviors.Count - 1; i >= 0; i--)
             {
-                var contextBehavior = contextBehaviors[i];
+                var (contextBehavior, contextBehaviorServiceType) = contextBehaviors[i];
                 var next = pipeline;
 
                 // Use reflection to call HandleAsync on the context behavior
-                var behaviorType = contextBehavior.GetType();
-                var handleAsyncMethod = behaviorType.GetMethod(nameof(IContextPipelineBehavior<object, TResponse>.HandleAsync));
+                var handleAsyncMethod = contextBehaviorServiceType.GetMethod(nameof(IContextPipelineBehavior<object, TResponse>.HandleAsync));
 
                 if (handleAsyncMethod == null)
                 {
-                    throw new InvalidOperationException($"HandleAsync method not found on context pipeline behavior {behaviorType.Name}");
+                    throw new InvalidOperationException($"HandleAsync method not found on context pipeline behavior {contextBehaviorServiceType.Name}");
                 }
 
                 pipeline = () =>

--- a/src/Medino/Mediator.cs
+++ b/src/Medino/Mediator.cs
@@ -57,7 +57,9 @@ public class Mediator : IMediator
         }
 
         // Get context behaviors (for request transformation)
-        // Look for both concrete type and object-based behaviors
+        // Look for both concrete type and object-based behaviors.
+        // Each behavior is paired with the closed interface ServiceType it was resolved from so that
+        // HandleAsync can later be resolved unambiguously even when one class implements several behaviors.
         var contextBehaviorType = typeof(IContextPipelineBehavior<,>).MakeGenericType(requestType, typeof(TResponse));
         var contextBehaviors = GetServices(contextBehaviorType)
             .Select(behavior => (Behavior: behavior, ServiceType: contextBehaviorType))
@@ -129,11 +131,15 @@ public class Mediator : IMediator
                 var (behavior, behaviorServiceType) = behaviors[i];
                 var next = pipeline;
 
+                // Resolve HandleAsync on the closed interface type rather than the concrete type.
+                // A behavior may implement several closed IPipelineBehavior<,> interfaces (one HandleAsync
+                // overload each); looking the method up by name on the concrete type would throw
+                // AmbiguousMatchException, so we use the unambiguous interface method instead.
                 var handleAsyncMethod = behaviorServiceType.GetMethod(nameof(IPipelineBehavior<object, TResponse>.HandleAsync));
 
                 if (handleAsyncMethod == null)
                 {
-                    throw new InvalidOperationException($"HandleAsync method not found on pipeline behavior {behaviorServiceType.Name}");
+                    throw new InvalidOperationException($"HandleAsync method not found on pipeline behavior {behavior.GetType().Name} ({behaviorServiceType.Name})");
                 }
 
                 pipeline = () =>
@@ -164,12 +170,14 @@ public class Mediator : IMediator
                 var (contextBehavior, contextBehaviorServiceType) = contextBehaviors[i];
                 var next = pipeline;
 
-                // Use reflection to call HandleAsync on the context behavior
+                // Resolve HandleAsync on the closed interface type (see note above) so that a behavior
+                // implementing multiple closed IContextPipelineBehavior<,> interfaces resolves the
+                // correct overload instead of throwing AmbiguousMatchException.
                 var handleAsyncMethod = contextBehaviorServiceType.GetMethod(nameof(IContextPipelineBehavior<object, TResponse>.HandleAsync));
 
                 if (handleAsyncMethod == null)
                 {
-                    throw new InvalidOperationException($"HandleAsync method not found on context pipeline behavior {contextBehaviorServiceType.Name}");
+                    throw new InvalidOperationException($"HandleAsync method not found on context pipeline behavior {contextBehavior.GetType().Name} ({contextBehaviorServiceType.Name})");
                 }
 
                 pipeline = () =>


### PR DESCRIPTION
## Summary
- Fix pipeline behavior invocation when a single behavior implementation has multiple public `HandleAsync` overloads by implementing multiple closed `IPipelineBehavior<,>` interfaces.
- Apply the same closed-interface lookup to `IContextPipelineBehavior<,>` invocation.
- Add regression tests that verify the matching overload is invoked for both regular and context pipeline behaviors.

## Root cause
`Mediator` resolved the correct closed behavior service type, but then called `behavior.GetType().GetMethod("HandleAsync")` by name only. If the implementation type exposes multiple `HandleAsync` overloads, reflection throws `AmbiguousMatchException` before invoking the matching closed behavior.

## Validation
- `dotnet build src\Medino.slnx --no-restore`
- `dotnet test src\Medino.Tests\Medino.Tests.csproj --no-restore`