### PR TITLE
Consolidate Renovate dependency updates

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.4.16",
+      "version": "5.5.10",
       "commands": [
         "reportgenerator"
       ],

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,14 +33,14 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: test-results
         path: '**/test-results.trx'
 
     - name: Upload coverage reports
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: coverage-reports
         path: TestResults/**/coverage.cobertura.xml

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0  # GitVersion needs full history
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
         fetch-depth: 0  # GitVersion needs full history
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
           8.0.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         fetch-depth: 0  # GitVersion needs full history
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
           8.0.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0  # GitVersion needs full history
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,34 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "groupName": "github actions",
+      "matchManagers": ["github-actions"]
+    },
+    {
+      "groupName": "test dependencies",
+      "matchPackageNames": [
+        "/^xunit/",
+        "/^Microsoft\\.NET\\.Test\\.Sdk$/",
+        "/^coverlet\\./",
+        "/^dotnet-reportgenerator-globaltool$/"
+      ]
+    },
+    {
+      "groupName": "microsoft extensions",
+      "matchPackageNames": [
+        "/^Microsoft\\.Extensions\\./"
+      ]
+    },
+    {
+      "groupName": "build tooling",
+      "matchPackageNames": [
+        "/^GitVersion/",
+        "/^DotNet\\.ReproducibleBuilds$/",
+        "/^Microsoft\\.SourceLink/"
+      ]
+    }
   ]
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All"/>
-    <PackageReference Include="GitVersion.MsBuild" Version="6.0.5" PrivateAssets="All"/>
+    <PackageReference Include="GitVersion.MsBuild" Version="6.8.1" PrivateAssets="All"/>
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All"/>
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39" PrivateAssets="All"/>
     <PackageReference Include="GitVersion.MsBuild" Version="6.0.5" PrivateAssets="All"/>
   </ItemGroup>
 

--- a/src/Medino.Extensions.DependencyInjection/Medino.Extensions.DependencyInjection.csproj
+++ b/src/Medino.Extensions.DependencyInjection/Medino.Extensions.DependencyInjection.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Medino.Tests/Medino.Tests.csproj
+++ b/src/Medino.Tests/Medino.Tests.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Medino.Tests/Medino.Tests.csproj
+++ b/src/Medino.Tests/Medino.Tests.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.17" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Medino.Tests/Medino.Tests.csproj
+++ b/src/Medino.Tests/Medino.Tests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Medino.Tests/Medino.Tests.csproj
+++ b/src/Medino.Tests/Medino.Tests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
- Merges 10 open Renovate dependency-update PRs into a single PR: #34 #33 #31 #30 #29 #28 #20 #19 #15 #13
- Bumps `actions/checkout` v4→v7, `actions/setup-dotnet` v4→v5, `actions/upload-artifact` v4→v7
- Bumps `Microsoft.NET.Test.Sdk` 17.11.1→17.14.1, `xunit` 2.9.2→2.9.3, `coverlet.collector` 6.0.2→6.0.4
- Bumps `Microsoft.Extensions.DependencyInjection(.Abstractions)` 8.0.0→8.0.2 / 9.0.0→9.0.17
- Bumps `GitVersion.MsBuild` 6.0.5→6.8.1, `DotNet.ReproducibleBuilds` 1.2.25→1.2.39
- Bumps `dotnet-reportgenerator-globaltool` 5.4.16→5.5.10
- Adds `packageRules` to `renovate.json` to group GitHub Actions, test dependencies, `Microsoft.Extensions.*`, and build tooling into single grouped PRs going forward, instead of one PR per package

## Test plan
- [x] `dotnet build src/Medino.slnx` succeeds (net8.0/net9.0/net10.0)
- [x] `dotnet test src/Medino.Tests/Medino.Tests.csproj` — 66/66 passing
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)