### PR TITLE
Consolidate Renovate major dependency updates

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All"/>
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="2.0.5" PrivateAssets="All"/>
     <PackageReference Include="GitVersion.MsBuild" Version="6.8.1" PrivateAssets="All"/>
   </ItemGroup>
 

--- a/src/Medino.Extensions.DependencyInjection/Medino.Extensions.DependencyInjection.csproj
+++ b/src/Medino.Extensions.DependencyInjection/Medino.Extensions.DependencyInjection.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Medino.Tests/Medino.Tests.csproj
+++ b/src/Medino.Tests/Medino.Tests.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.17" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Merges 2 open Renovate PRs: #38 #37
- Bumps `Microsoft.Extensions.DependencyInjection` / `.Abstractions` 8.0.2/9.0.17 → 10.0.9 (major)
- Bumps `Microsoft.SourceLink.GitHub` 8.0.0 → 10.0.300 (major, build-time only)
- Bumps `DotNet.ReproducibleBuilds` 1.2.39 → 2.0.5 (major, build-time only)

## Test plan
- [x] `dotnet build src/Medino.slnx` succeeds (net8.0/net9.0/net10.0)
- [x] `dotnet build src/Medino.Extensions.DependencyInjection -f net8.0` succeeds with no downgrade/restore warnings
- [x] `dotnet test src/Medino.Tests/Medino.Tests.csproj` — 66/66 passing
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)